### PR TITLE
Add and fix deprecation/lint warnings and add JDK9 to travis tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /build/
 /dist/
 /target/
+
+.classpath
+.project
+.settings/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+dist: trusty
 jdk:
 - openjdk7
 - oraclejdk8
+- oraclejdk9

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.owasp</groupId>
     <artifactId>java-file-io</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>OWASP Java File IO</name>
     <description>The OWASP Java File I/O Security Project provides an easy to use library for validating and sanitizing filenames, directory paths, and uploaded files.</description>
@@ -29,20 +29,49 @@
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <targetJdk>1.7</targetJdk>
     </properties>
     <build>
         <pluginManagement>
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId> 
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId> 
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId> 
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.7.0</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>${targetJdk}</source>
+                        <target>${targetJdk}</target>
+                        <showWarnings>true</showWarnings>
+                        <showDeprecation>true</showDeprecation>
+                        <compilerArgs>
+                            <arg>-Xlint</arg>
+                        </compilerArgs>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId> 
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId> 
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.20.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId> 
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -68,7 +97,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
+                        <version>3.0.0-M1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -111,7 +140,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/owasp/fileio/Encoder.java
+++ b/src/main/java/org/owasp/fileio/Encoder.java
@@ -67,7 +67,7 @@ public class Encoder {
 	return singletonInstance;
     }
     // Codecs
-    private List codecs = new ArrayList();
+    private List<Codec> codecs = new ArrayList<>();
     private HTMLEntityCodec htmlCodec = new HTMLEntityCodec();
     private PercentCodec percentCodec = new PercentCodec();
 
@@ -123,9 +123,9 @@ public class Encoder {
 	    clean = true;
 
 	    // try each codec and keep track of which ones work
-	    Iterator i = codecs.iterator();
+	    Iterator<Codec> i = codecs.iterator();
 	    while (i.hasNext()) {
-		Codec codec = (Codec) i.next();
+		Codec codec = i.next();
 		String old = working;
 		working = codec.decode(working);
 		if (!old.equals(working)) {

--- a/src/main/java/org/owasp/fileio/StringValidationRule.java
+++ b/src/main/java/org/owasp/fileio/StringValidationRule.java
@@ -307,7 +307,7 @@ public class StringValidationRule {
      * {@inheritDoc}
      */
     public String whitelist(String input, char[] whitelist) {
-	Set whiteSet = Utils.arrayToSet(whitelist);
+	Set<Character> whiteSet = Utils.arrayToSet(whitelist);
 	return whitelist(input, whiteSet);
     }
 

--- a/src/main/java/org/owasp/fileio/codecs/HTMLEntityCodec.java
+++ b/src/main/java/org/owasp/fileio/codecs/HTMLEntityCodec.java
@@ -23,6 +23,7 @@ public class HTMLEntityCodec extends Codec {
 
     private static final char REPLACEMENT_CHAR = '\ufffd';
     private static final String REPLACEMENT_HEX = "fffd";
+    @SuppressWarnings("unused")
     private static final String REPLACEMENT_STR = "" + REPLACEMENT_CHAR;
     private static final Map<Character, String> characterToEntityMap = mkCharacterToEntityMap();
     private static final Trie<Character> entityToCharacterTrie = mkEntityToCharacterTrie();
@@ -61,7 +62,7 @@ public class HTMLEntityCodec extends Codec {
 	}
 
 	// check if there's a defined entity
-	String entityName = (String) characterToEntityMap.get(c);
+	String entityName = characterToEntityMap.get(c);
 	if (entityName != null) {
 	    return "&" + entityName + ";";
 	}

--- a/src/main/java/org/owasp/fileio/codecs/HashTrie.java
+++ b/src/main/java/org/owasp/fileio/codecs/HashTrie.java
@@ -107,14 +107,15 @@ public class HashTrie<T> implements Trie<T> {
 	/**
 	 * *****************
 	 */
-	public boolean equals(Map.Entry other) {
+	public boolean equals(Map.Entry<CharSequence, T> other) {
 	    return (NullSafe.equals(key, other.getKey()) && NullSafe.equals(value, other.getValue()));
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public boolean equals(Object o) {
 	    if (o instanceof Map.Entry) {
-		return equals((Map.Entry) o);
+		return equals((Map.Entry<CharSequence, T>) o);
 	    }
 	    return false;
 	}
@@ -198,10 +199,10 @@ public class HashTrie<T> implements Trie<T> {
 	    ch = key.charAt(pos);
 	    if (nextMap == null) {
 		nextMap = newNodeMap();
-		nextNode = new Node();
+		nextNode = new Node<>();
 		nextMap.put(ch, nextNode);
 	    } else if ((nextNode = nextMap.get(ch)) == null) {
-		nextNode = new Node();
+		nextNode = new Node<>();
 		nextMap.put(ch, nextNode);
 	    }
 	    return nextNode.put(key, pos + 1, addValue);
@@ -291,6 +292,7 @@ public class HashTrie<T> implements Trie<T> {
 	/**
 	 * Recursively rebuild the internal maps.
 	 */
+	@SuppressWarnings("unused")
 	void remap() {
 	    if (nextMap == null) {
 		return;
@@ -378,7 +380,7 @@ public class HashTrie<T> implements Trie<T> {
 
 	    if (value != null) // MUST toString here
 	    {
-		entries.add(new Entry(key.toString(), value));
+		entries.add(new Entry<>(key.toString(), value));
 	    }
 	    if (nextMap != null && nextMap.size() > 0) {
 		key.append('X');
@@ -597,7 +599,8 @@ public class HashTrie<T> implements Trie<T> {
     /**
      * {@inheritDoc}
      */
-    @Override
+    @SuppressWarnings("unchecked")
+	@Override
     public boolean equals(Object other) {
 	if (other == null) {
 	    return false;
@@ -606,7 +609,7 @@ public class HashTrie<T> implements Trie<T> {
 	    return false;
 	}
 	// per spec
-	return entrySet().equals(((Map) other).entrySet());
+	return entrySet().equals(((Map<CharSequence, T>) other).entrySet());
     }
 
     /**

--- a/src/test/java/org/owasp/fileio/FileValidatorTest.java
+++ b/src/test/java/org/owasp/fileio/FileValidatorTest.java
@@ -5,12 +5,9 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
 import static org.junit.Assert.*;
+
+import org.junit.Test;
 import org.owasp.fileio.codecs.Codec;
 import org.owasp.fileio.codecs.HTMLEntityCodec;
 
@@ -18,15 +15,11 @@ import org.owasp.fileio.codecs.HTMLEntityCodec;
  *
  * @author August Detlefsen <augustd at codemagi dot com>
  */
-public class FileValidatorTest extends TestCase {
+public class FileValidatorTest {
 
     private static final String PREFERRED_ENCODING = "UTF-8";
 
-    public static junit.framework.Test suite() {
-	TestSuite suite = new TestSuite(FileValidatorTest.class);
-	return suite;
-    }
-
+    @Test
     public void testIsValidFileName() {
 	System.out.println("isValidFileName");
 	FileValidator instance = new FileValidator();
@@ -41,6 +34,7 @@ public class FileValidatorTest extends TestCase {
 	assertTrue(errors.isEmpty());
     }
 
+    @Test
     public void testIsValidFileUpload() throws IOException {
 	System.out.println("isValidFileUpload");
 	String filepath = new File(System.getProperty("user.dir")).getCanonicalPath();
@@ -78,6 +72,7 @@ public class FileValidatorTest extends TestCase {
 	assertTrue(errors.size() == 1);
     }
 
+    @Test
     public void testIsInvalidFilename() {
 	System.out.println("testIsInvalidFilename");
 	FileValidator instance = new FileValidator();
@@ -91,6 +86,7 @@ public class FileValidatorTest extends TestCase {
 	assertFalse("Filennames cannot be the empty string", instance.isValidFileName("test", "", false));
     }
 
+    @Test
     public void testIsValidDirectoryPath() throws IOException {
 	System.out.println("isValidDirectoryPath");
 
@@ -204,6 +200,7 @@ public class FileValidatorTest extends TestCase {
 	}
     }
 
+    @Test
     public void TestIsValidDirectoryPath() {
 	// isValidDirectoryPath(String, String, boolean)
     }

--- a/src/test/java/org/owasp/fileio/SafeFileTest.java
+++ b/src/test/java/org/owasp/fileio/SafeFileTest.java
@@ -13,39 +13,34 @@
 package org.owasp.fileio;
 
 import org.owasp.fileio.util.FileTestUtils;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.util.Iterator;
 import java.util.Set;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.owasp.fileio.util.CollectionsUtil;
 
-public class SafeFileTest extends TestCase {
+public class SafeFileTest {
 
-    private static final Class CLASS = SafeFileTest.class;
+    private static final Class<?> CLASS = SafeFileTest.class;
     private static final String CLASS_NAME = CLASS.getName();
     
     /**
      * Name of the file in the temporary directory
      */
     private static final String TEST_FILE_NAME = "test.file";
-    private static final Set GOOD_FILE_CHARS = CollectionsUtil.strToUnmodifiableSet("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-" /* + "." */);
-    private static final Set BAD_FILE_CHARS = CollectionsUtil.strToUnmodifiableSet("\u0000" + /*(File.separatorChar == '/' ? '\\' : '/') +*/ "*|<>?:" /*+ "~!@#$%^&(){}[],`;"*/);
+    private static final Set<Character> GOOD_FILE_CHARS = CollectionsUtil.strToUnmodifiableSet("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-" /* + "." */);
+    private static final Set<Character> BAD_FILE_CHARS = CollectionsUtil.strToUnmodifiableSet("\u0000" + /*(File.separatorChar == '/' ? '\\' : '/') +*/ "*|<>?:" /*+ "~!@#$%^&(){}[],`;"*/);
     private File testDir = null;
     private File testFile = null;
     String pathWithNullByte = "/temp/file.txt" + (char) 0;
 
-    /**
-     * {@inheritDoc}
-     */
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
 	// create a file to test with
 	testDir = FileTestUtils.createTmpDirectory(CLASS_NAME).getCanonicalFile();
 	testFile = new File(testDir, TEST_FILE_NAME);
@@ -53,18 +48,12 @@ public class SafeFileTest extends TestCase {
 	testFile = testFile.getCanonicalFile();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
 	FileTestUtils.deleteRecursively(testDir);
     }
 
-    public static Test suite() {
-	TestSuite suite = new TestSuite(SafeFileTest.class);
-	return suite;
-    }
-
+    @Test
     public void testEscapeCharactersInFilename() {
 	System.out.println("testEscapeCharactersInFilenameInjection");
 	File tf = testFile;
@@ -80,6 +69,7 @@ public class SafeFileTest extends TestCase {
 	}
     }
 
+    @Test
     public void testEscapeCharacterInDirectoryInjection() {
 	System.out.println("testEscapeCharacterInDirectoryInjection");
 	File sf = new File(testDir, "test\\^.^.\\file");
@@ -90,8 +80,9 @@ public class SafeFileTest extends TestCase {
 	}
     }
 
+    @Test
     public void testJavaFileInjectionGood() throws ValidationException {
-	for (Iterator i = GOOD_FILE_CHARS.iterator(); i.hasNext();) {
+	for (Iterator<Character> i = GOOD_FILE_CHARS.iterator(); i.hasNext();) {
 	    String ch = i.next().toString();	// avoids generic issues in 1.4&1.5
 	    File sf = new SafeFile(testDir, TEST_FILE_NAME + ch);
 	    assertFalse("File \"" + TEST_FILE_NAME + ch + "\" should not exist ((int)ch=" + (int) ch.charAt(0) + ").", sf.exists());
@@ -100,24 +91,26 @@ public class SafeFileTest extends TestCase {
 	}
     }
 
+    @Test
     public void testJavaFileInjectionBad() {
-	for (Iterator i = BAD_FILE_CHARS.iterator(); i.hasNext();) {
+	for (Iterator<Character> i = BAD_FILE_CHARS.iterator(); i.hasNext();) {
 	    String ch = i.next().toString();	// avoids generic issues in 1.4&1.5
 	    try {
-		File sf = new SafeFile(testDir, TEST_FILE_NAME + ch);
+		new SafeFile(testDir, TEST_FILE_NAME + ch);
 		fail("Able to create SafeFile \"" + TEST_FILE_NAME + ch + "\" ((int)ch=" + (int) ch.charAt(0) + ").");
 	    } catch (ValidationException expected) {
 	    }
 	    try {
-		File sf = new SafeFile(testDir, TEST_FILE_NAME + ch + "test");
+		new SafeFile(testDir, TEST_FILE_NAME + ch + "test");
 		fail("Able to create SafeFile \"" + TEST_FILE_NAME + ch + "\" ((int)ch=" + (int) ch.charAt(0) + ").");
 	    } catch (ValidationException expected) {
 	    }
 	}
     }
 
+    @Test
     public void testMultipleJavaFileInjectionGood() throws ValidationException {
-	for (Iterator i = GOOD_FILE_CHARS.iterator(); i.hasNext();) {
+	for (Iterator<Character> i = GOOD_FILE_CHARS.iterator(); i.hasNext();) {
 	    String ch = i.next().toString();	// avoids generic issues in 1.4&1.5
 	    ch = ch + ch + ch;
 	    File sf = new SafeFile(testDir, TEST_FILE_NAME + ch);
@@ -127,23 +120,25 @@ public class SafeFileTest extends TestCase {
 	}
     }
 
+    @Test
     public void testMultipleJavaFileInjectionBad() {
-	for (Iterator i = BAD_FILE_CHARS.iterator(); i.hasNext();) {
+	for (Iterator<Character> i = BAD_FILE_CHARS.iterator(); i.hasNext();) {
 	    String ch = i.next().toString();	// avoids generic issues in 1.4&1.5
 	    ch = ch + ch + ch;
 	    try {
-		File sf = new SafeFile(testDir, TEST_FILE_NAME + ch);
+		new SafeFile(testDir, TEST_FILE_NAME + ch);
 		fail("Able to create SafeFile \"" + TEST_FILE_NAME + ch + "\" ((int)ch=" + (int) ch.charAt(0) + ").");
 	    } catch (ValidationException expected) {
 	    }
 	    try {
-		File sf = new SafeFile(testDir, TEST_FILE_NAME + ch + "test");
+		new SafeFile(testDir, TEST_FILE_NAME + ch + "test");
 		fail("Able to create SafeFile \"" + TEST_FILE_NAME + ch + "\" ((int)ch=" + (int) ch.charAt(0) + ").");
 	    } catch (ValidationException expected) {
 	    }
 	}
     }
 
+    @Test
     public void testAlternateDataStream() {
 	try {
 	    File sf = new SafeFile(testDir, TEST_FILE_NAME + ":secret.txt");
@@ -152,9 +147,10 @@ public class SafeFileTest extends TestCase {
 	}
     }
     
+    @Test
     public void testSafeFileWithoutPath() {
         try {
-            File sf = new SafeFile("hello.txt");
+            new SafeFile("hello.txt");
         } catch (ValidationException expected) {
 	}
     }
@@ -165,64 +161,73 @@ public class SafeFileTest extends TestCase {
 	return new String(array);
     }
 
+    @Test
     public void testCreatePath() throws Exception {
 	SafeFile sf = new SafeFile(testFile.getPath());
 	assertTrue(sf.exists());
     }
 
+    @Test
     public void testCreateParentPathName() throws Exception {
 	SafeFile sf = new SafeFile(testDir, testFile.getName());
 	assertTrue(sf.exists());
     }
 
+    @Test
     public void testCreateParentFileName() throws Exception {
 	SafeFile sf = new SafeFile(testFile.getParentFile(), testFile.getName());
 	assertTrue(sf.exists());
     }
 
+    @Test
     public void testCreateURI() throws Exception {
 	SafeFile sf = new SafeFile(testFile.toURI());
 	assertTrue(sf.exists());
     }
 
+    @Test
     public void testCreateFileNamePercentNull() {
 	try {
-	    SafeFile sf = new SafeFile(testDir + File.separator + "file%00.txt");
+	    new SafeFile(testDir + File.separator + "file%00.txt");
 	    fail("no exception thrown for file name with percent encoded null");
 	} catch (ValidationException expected) {
 	}
     }
 
+    @Test
     public void testCreateFileNameQuestion() {
 	try {
-	    SafeFile sf = new SafeFile(testFile.getParent() + File.separator + "file?.txt");
+	    new SafeFile(testFile.getParent() + File.separator + "file?.txt");
 	    fail("no exception thrown for file name with question mark in it");
 	} catch (ValidationException e) {
 	    // expected
 	}
     }
 
+    @Test
     public void testCreateFileNameNull() {
 	try {
-	    SafeFile sf = new SafeFile(testFile.getParent() + File.separator + "file" + ((char) 0) + ".txt");
+	    new SafeFile(testFile.getParent() + File.separator + "file" + ((char) 0) + ".txt");
 	    fail("no exception thrown for file name with null in it");
 	} catch (ValidationException e) {
 	    // expected
 	}
     }
 
+    @Test
     public void testCreateFileHighByte() {
 	try {
-	    SafeFile sf = new SafeFile(testFile.getParent() + File.separator + "file" + ((char) 160) + ".txt");
+	    new SafeFile(testFile.getParent() + File.separator + "file" + ((char) 160) + ".txt");
 	    fail("no exception thrown for file name with high byte in it");
 	} catch (ValidationException e) {
 	    // expected
 	}
     }
 
+    @Test
     public void testCreateParentPercentNull() {
 	try {
-	    SafeFile sf = new SafeFile(testFile.getParent() + File.separator + "file%00.txt");
+	    new SafeFile(testFile.getParent() + File.separator + "file%00.txt");
 	    fail("no exception thrown for file name with percent encoded null");
 	} catch (ValidationException e) {
 	    // expected

--- a/src/test/java/org/owasp/fileio/util/FileTestUtils.java
+++ b/src/test/java/org/owasp/fileio/util/FileTestUtils.java
@@ -22,7 +22,7 @@ import java.util.Random;
  */
 public class FileTestUtils {
 
-    private static final Class CLASS = FileTestUtils.class;
+    private static final Class<?> CLASS = FileTestUtils.class;
     private static final String CLASS_NAME = CLASS.getName();
     private static final String DEFAULT_PREFIX = CLASS_NAME + '.';
     private static final String DEFAULT_SUFFIX = ".tmp";


### PR DESCRIPTION
Switched on deprecation and lint warnings in maven built and fixes deprecation and lint warnings in the current code. The reasoning for doing this is that a safety oriented library should have all compiler warnings visible (although I didn't make them error the build at this point).

Also adds JDK9 to travis configuration to test its compatibility. JDK9 build requires newer Maven plugin versions than the defaults, so also bumping those to latest in each case.

Also switches tests to work using JUnit-4 style, which may help with a future JUnit-5 migration (which is not done here).